### PR TITLE
44 ‍ verbose flag most functions

### DIFF
--- a/scheduling/app/utils/os_structure.py
+++ b/scheduling/app/utils/os_structure.py
@@ -1,13 +1,16 @@
 import pandas as pd
 
 
-def write_schedule_to_excel(filename: str, data_path: str, assignments: list[dict[str, int | str]], agent_assignments: dict[str, int]):
+def write_schedule_to_excel(
+    filename: str, data_path: str, assignments: list[dict[str, int | str]], agent_assignments: dict[str, int], verbose: bool = True
+) -> None:
     """
     Writes the schedule and agent assignment counts to an Excel file.
 
     :param filename: Name of the Excel file to write to.
     :param assignments: List of assignment dictionaries with keys 'Day', 'Task' and 'Agent'.
     :param agent_assignments: Dictionary with agent names as keys and total assignments as values.
+    :param verbose: (optional) If True, prints the filename. Default is True.
     """
     schedule_df = pd.read_excel(data_path, index_col=0, sheet_name="doctor_charts")
     task_df = pd.read_excel(data_path, index_col=0, sheet_name="tasks")
@@ -31,4 +34,5 @@ def write_schedule_to_excel(filename: str, data_path: str, assignments: list[dic
         task_df.to_excel(writer, sheet_name="Task Assignments")
         agent_assignments_df.to_excel(writer, sheet_name="Agent Assignments", index=False)
 
-    print(f"Schedule and agent assignments written to {filename}")
+    if verbose:
+        print(f"Schedule and agent assignments written to {filename}")

--- a/wtb/app/utils/data_formatting.py
+++ b/wtb/app/utils/data_formatting.py
@@ -107,7 +107,6 @@ def update_taskboards_with_stuefordeling(weekly_taskboards: list[TaskBoard]) -> 
                 function_stripped = strip_str(function)
 
                 if function_stripped not in function_names_stripped:  # <-- NOTE: make search on stripped, lower-case name
-                    print(f"Function '{function}' not found in the taskboard  {indx}.")
                     if non_matching_functions[indx] is None:
                         non_matching_functions[indx] = []
                     non_matching_functions[indx].append(function)

--- a/wtb/app/utils/os_structure.py
+++ b/wtb/app/utils/os_structure.py
@@ -12,7 +12,7 @@ def get_week_dates_from_today(today: datetime.date, weekday: int) -> list[dateti
     return [start_of_week + datetime.timedelta(days=i) for i in range(7)]
 
 
-def save_weekly_taskboards(weekly_taskboards: list[TaskBoard], num_weekdays: int = 7) -> None:
+def save_weekly_taskboards(weekly_taskboards: list[TaskBoard], num_weekdays: int = 7, verbose: bool = True) -> None:
     """ """
     today = datetime.date.today()
     year, week, weekday = today.isocalendar()
@@ -26,13 +26,17 @@ def save_weekly_taskboards(weekly_taskboards: list[TaskBoard], num_weekdays: int
 
     for i in range(num_weekdays):
         if weekly_taskboards[i] is None:
-            print(f"The {i + 1}th TaskBoard of the week was EMPTY and NOT saved.")
+            if verbose:
+                print(f"The {i + 1}th TaskBoard of the week was EMPTY and NOT saved.")
             continue
+
         name = str(week_dates[i])
         df = weekly_taskboards[i].to_dataframe()
         df.to_excel(dir_path + name + ".xlsx", index=False, engine="openpyxl")
-        print(f"Saved {i + 1}th TaskBoard of the week succesfully as: {dir_path + name}.xlsx")
-        print(f"DataFrame:\n{df}\n")
+
+        if verbose:
+            print(f"Saved {i + 1}th TaskBoard of the week succesfully as: {dir_path + name}.xlsx")
+            print(f"DataFrame:\n{df}\n")
 
 
 def get_html_save_path() -> str:

--- a/wtb/app/utils/webscrape.py
+++ b/wtb/app/utils/webscrape.py
@@ -12,11 +12,12 @@ from selenium.webdriver.support.ui import WebDriverWait
 from app.utils.os_structure import get_html_save_path
 
 
-def get_soup_from_altiplan(config: dict[str, any] = None) -> bs4.BeautifulSoup | None:
+def get_soup_from_altiplan(verbose: bool = True, config: dict[str, any] = None) -> bs4.BeautifulSoup | None:
     """
     Uses Selenium to scrape the Altiplan website (with the configurations given by a config)
     and returns the HTML as a BeautifulSoup object.
 
+    :param verbose: A boolean indicating whether to print the status of the scraping process. Default is True.
     :param config: A dictionary containing the configurations for the scraping process.
 
     :return: A BeautifulSoup object containing the HTML of the Altiplan website.
@@ -38,7 +39,8 @@ def get_soup_from_altiplan(config: dict[str, any] = None) -> bs4.BeautifulSoup |
 
     html_save_path = get_html_save_path()
     if not run_selenium_regardless and os.path.exists(html_save_path):
-        print("HTML already fetched.")
+        if verbose:
+            print("HTML already fetched.")
         with open(html_save_path, "r", encoding="utf-8") as file:
             return bs4.BeautifulSoup(file.read(), "html.parser")
 
@@ -77,7 +79,8 @@ def get_soup_from_altiplan(config: dict[str, any] = None) -> bs4.BeautifulSoup |
         # Wait for the login process to complete
         wait.until(ec.presence_of_element_located((By.XPATH, js_xpath_unique_afterlogin_elem)))
 
-        print("Login successful.")
+        if verbose:
+            print("Login successful.")
 
         # Navigate to the target page
         driver.get(url_schedule)


### PR DESCRIPTION
The aim of this PR was to add a `verbose` flag to functions that print a lot. It was because, when I tested the visualisation functionality I kept getting a lot of prints to the terminal I thought that it was highly unnecessary.
(Just a note, what I mean by verbosity is whether a function says anything or is silent. If the verbosity message is toggled as `False`, then the function in question would still give error messages - these aren't silenced.)